### PR TITLE
payer_admin roles should be able to make a reimbursement

### DIFF
--- a/src/lib/config/roles-permissions.js
+++ b/src/lib/config/roles-permissions.js
@@ -213,7 +213,7 @@ export const ROLE_PERMISSIONS = {
     ...enrollmentStatisticsPermissions,
     ...memberViewOnlyPermissions,
     ...reimbursementStatisticsPermissions,
-    ...reimbursementsViewOnlyPermissions,
+    ...reimbursementPaymentPermissions,
   ],
   adjudication: [
     ROLES.ADJUDICATION,
@@ -223,6 +223,7 @@ export const ROLE_PERMISSIONS = {
     ...reimbursementStatisticsPermissions,
     ...claimsReimbursementPermissions,
     ...reimbursementPaymentPermissions,
+    ...reimbursementsViewOnlyPermissions,
   ],
   enrollment: [
     ROLES.ENROLLMENT,

--- a/src/lib/config/roles-permissions.js
+++ b/src/lib/config/roles-permissions.js
@@ -222,7 +222,6 @@ export const ROLE_PERMISSIONS = {
     ...claimsStatisticsPermissions,
     ...reimbursementStatisticsPermissions,
     ...claimsReimbursementPermissions,
-    ...reimbursementPaymentPermissions,
     ...reimbursementsViewOnlyPermissions,
   ],
   enrollment: [


### PR DESCRIPTION
User with role: `payer_admin` should be able to make a reimbursement
User with role: `adjudication` should not be able to make a reimbursement (and have view only permissions)
